### PR TITLE
Cherry pick additional features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
-  - openjdk6
-

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.scm.vendor>git</project.scm.vendor>
     <project.java.version>1.5</project.java.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <aws.version>1.6.4</aws.version>
+    <aws.version>1.11.16</aws.version>
     <spring.version>3.2.5.RELEASE</spring.version>
     <kuali-s3.version>1.0.1</kuali-s3.version>
     <junit.version>4.11</junit.version>
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
+      <artifactId>aws-java-sdk-s3</artifactId>
       <version>${aws.version}</version>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/kuali/maven/wagon/S3Wagon.java
+++ b/src/main/java/org/kuali/maven/wagon/S3Wagon.java
@@ -99,7 +99,6 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	public static final int DEFAULT_MAX_THREAD_COUNT = 50;
 	public static final int DEFAULT_DIVISOR = 50;
 	public static final int DEFAULT_READ_TIMEOUT = 60 * 1000;
-	public static final CannedAccessControlList DEFAULT_ACL = CannedAccessControlList.PublicRead;
 	private static final File TEMP_DIR = getCanonicalFile(System.getProperty("java.io.tmpdir"));
 	private static final String TEMP_DIR_PATH = TEMP_DIR.getAbsolutePath();
 
@@ -111,7 +110,7 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 	String protocol = getValue(PROTOCOL_KEY, HTTPS);
 	boolean http = HTTP.equals(protocol);
 	int readTimeout = DEFAULT_READ_TIMEOUT;
-	CannedAccessControlList acl = DEFAULT_ACL;
+	CannedAccessControlList acl = null;
 	TransferManager transferManager;
 
 	private static final Logger log = LoggerFactory.getLogger(S3Wagon.class);
@@ -388,7 +387,9 @@ public class S3Wagon extends AbstractWagon implements RequestFactory {
 			InputStream input = getInputStream(source, progress);
 			ObjectMetadata metadata = getObjectMetadata(source, destination);
 			PutObjectRequest request = new PutObjectRequest(bucketName, key, input, metadata);
-			request.setCannedAcl(acl);
+			if (acl != null) {
+				request.setCannedAcl(acl);
+			}
 			return request;
 		} catch (FileNotFoundException e) {
 			throw new AmazonServiceException("File not found", e);


### PR DESCRIPTION
Incorporated features from outstanding pull requests on original project, including some by @mdedetrich

Removed setting of ACL to "Public" as a default. This isn't desired behaviour for private repos
Add support for reading AWS credentials from ~/.aws/credentials
Add support for Amazon EC2 Container Service
Depend only on aws-java-sdk-s3 instead of entire SDK.
Fix travis to work in trusty.