### PR TITLE
Missing JAXB dependency for JDK 11 mvn deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<kuali-s3.version>1.0.1</kuali-s3.version>
 		<junit.version>4.11</junit.version>
 		<guava.version>15.0</guava.version>
+		<jaxb.version>2.3.2</jaxb.version>
 	</properties>
 	<build>
 		<plugins>
@@ -126,6 +127,11 @@
 			<artifactId>jcl-over-slf4j</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+		<dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jaxb.version}</version>
+                </dependency>
 	</dependencies>
 	<scm>
 		<connection>scm:git:https://github.com/seahen/maven-s3-wagon.git</connection>


### PR DESCRIPTION
When using JDK11 as the default, doing a `mvn clean deploy` fails to run the deploy plugin, due to a missing dependency in the S3 wagon provider.  Using `mvn clean deploy -X -e` showed that it was the wagon provider itself failing, not the plugin - when I added in this depenency, it worked correctly.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy (default-deploy) on project arcus-parent: Execution default-deploy of goal org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy failed: A required class was missing while executing org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy: javax/xml/bind/DatatypeConverter
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/var/lib/jenkins/.m2/repository/org/apache/maven/plugins/maven-deploy-plugin/3.0.0-M1/maven-deploy-plugin-3.0.0-M1.jar
[ERROR] urls[1] = file:/var/lib/jenkins/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
[ERROR] urls[2] = file:/var/lib/jenkins/.m2/repository/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
[ERROR] urls[3] = file:/var/lib/jenkins/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[4] = file:/var/lib/jenkins/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[5] = file:/var/lib/jenkins/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar
[ERROR] urls[6] = file:/var/lib/jenkins/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[7] = file:/var/lib/jenkins/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[8] = file:/var/lib/jenkins/.m2/repository/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar
[ERROR] urls[9] = file:/var/lib/jenkins/.m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar
[ERROR] urls[10] = file:/var/lib/jenkins/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar
[ERROR] urls[11] = file:/var/lib/jenkins/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
[ERROR] urls[12] = file:/var/lib/jenkins/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar
[ERROR] urls[13] = file:/var/lib/jenkins/.m2/repository/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] : javax.xml.bind.DatatypeConverter
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException